### PR TITLE
Move search bar to top and improve mobile layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,13 @@ Tests are located in `tests/` directory (not `src/`). Chirped has comprehensive 
 - Taxonomy processing tests
 - Sample data files for testing
 
+## Git Workflow
+
+- **Never amend commits** - always create new commits for additional changes
+- **Never force push** - use regular `git push` only
+- When making follow-up changes, create a new commit with a descriptive message
+- This preserves history and makes it easier to review changes
+
 ## Deployment Notes
 
 - Site configured for Render deployment at `https://beak-v2.onrender.com`

--- a/src/birds-eye/App.css
+++ b/src/birds-eye/App.css
@@ -25,7 +25,7 @@
   margin: 12px;
   border-radius: 4px;
   position: absolute;
-  top: 58px;
+  top: 0;
   left: 0;
   z-index: 1;
 }
@@ -38,24 +38,28 @@
   margin-left: 0;
 }
 
-/* Search bar styling - at top with matching dark theme */
-.mapboxgl-ctrl-top-left {
-  margin: 12px;
-  left: 0;
+/* Full width topBar on mobile */
+@media only screen and (max-width: 768px) {
+  .topBar {
+    right: 0;
+  }
 }
 
-.mapboxgl-ctrl-top-left .mapboxgl-ctrl {
-  margin: 0;
+/* Search bar container inside topBar */
+.geocoder-container {
+  margin-bottom: 8px;
+}
+
+.geocoder-container .mapboxgl-ctrl-geocoder {
+  min-width: 100%;
+  width: 100%;
 }
 
 .mapboxgl-ctrl-geocoder {
-  background-color: rgba(45, 57, 77, 0.95);
+  background-color: transparent;
   border-radius: 4px;
   box-shadow: none;
-}
-
-.mapboxgl-ctrl-geocoder:focus-within {
-  background-color: rgb(45, 57, 77);
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 .mapboxgl-ctrl-geocoder input,

--- a/src/birds-eye/App.css
+++ b/src/birds-eye/App.css
@@ -198,7 +198,10 @@
 /* if we're on mobile, put the species bar on the bottom */
 @media only screen and (max-width: 768px) {
   .right-species-bar {
+    position: absolute;
+    z-index: 1;
     bottom: 0;
+    left: 0;
     right: 0;
     margin: 12px;
     border-radius: 4px;

--- a/src/birds-eye/App.css
+++ b/src/birds-eye/App.css
@@ -15,8 +15,6 @@
 #map-container {
   display: flex;
   flex: 1;
-  /* temporarily set the background color so we can tell where the map container is positioned */
-  background-color: lightgrey;
 }
 
 .topBar {
@@ -27,7 +25,7 @@
   margin: 12px;
   border-radius: 4px;
   position: absolute;
-  top: 50;
+  top: 58px;
   left: 0;
   z-index: 1;
 }
@@ -39,6 +37,64 @@
 .topBar button:first-of-type {
   margin-left: 0;
 }
+
+/* Search bar styling - at top with matching dark theme */
+.mapboxgl-ctrl-top-left {
+  margin: 12px;
+  left: 0;
+}
+
+.mapboxgl-ctrl-top-left .mapboxgl-ctrl {
+  margin: 0;
+}
+
+.mapboxgl-ctrl-geocoder {
+  background-color: rgba(45, 57, 77, 0.95);
+  border-radius: 4px;
+  box-shadow: none;
+}
+
+.mapboxgl-ctrl-geocoder:focus-within {
+  background-color: rgb(45, 57, 77);
+}
+
+.mapboxgl-ctrl-geocoder input,
+.mapboxgl-ctrl-geocoder input:focus {
+  color: #fff !important;
+}
+
+.mapboxgl-ctrl-geocoder input::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon-search {
+  fill: #fff;
+}
+
+.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button {
+  background-color: transparent;
+}
+
+.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon-close {
+  fill: #fff;
+}
+
+.mapboxgl-ctrl-geocoder .suggestions {
+  background-color: rgb(45, 57, 77);
+  border-radius: 0 0 4px 4px;
+}
+
+.mapboxgl-ctrl-geocoder .suggestions li a,
+.mapboxgl-ctrl-geocoder .suggestions li.active a,
+.mapboxgl-ctrl-geocoder .suggestions li:first-child a {
+  color: #fff !important;
+}
+
+.mapboxgl-ctrl-geocoder .suggestions li a:hover,
+.mapboxgl-ctrl-geocoder .suggestions .active a {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
 .sidebar {
   background-color: rgba(45, 57, 77, 0.95);
   color: #fff;
@@ -146,11 +202,6 @@
 
   .checkbox-scroll-list {
     max-height: 20vh;
-  }
-
-  /* Position search bar with consistent margin */
-  .mapboxgl-ctrl-bottom-left {
-    bottom: -30px;
   }
 }
 

--- a/src/birds-eye/BirdMap.tsx
+++ b/src/birds-eye/BirdMap.tsx
@@ -389,6 +389,15 @@ export function BirdMap() {
       geocoderContainerRef.current.innerHTML = ''; // Clear any existing content
       geocoder.addTo(geocoderContainerRef.current);
     }
+    // Manually handle result since geocoder is in custom container
+    geocoder.on('result', (e: { result: { center: [number, number] } }) => {
+      mapRef.current?.flyTo({
+        center: e.result.center,
+        zoom: 12,
+        speed: 2.5,
+        essential: true,
+      });
+    });
 
     mapRef.current!.on('load', () => {
       fetchLifers(initialCenter.lat, initialCenter.lng, fileId).then((data) => {

--- a/src/birds-eye/BirdMap.tsx
+++ b/src/birds-eye/BirdMap.tsx
@@ -384,7 +384,7 @@ export function BirdMap() {
       placeholder: 'Search for a location',
       marker: false,
     });
-    mapRef.current.addControl(geocoder, 'bottom-left');
+    mapRef.current.addControl(geocoder, 'top-left');
 
     mapRef.current!.on('load', () => {
       fetchLifers(initialCenter.lat, initialCenter.lng, fileId).then((data) => {
@@ -963,6 +963,27 @@ export function BirdMap() {
         canClose={fileId !== ''}
       />
       <div className="topBar">
+        <div style={{ marginBottom: '8px' }}>
+          <button
+            onClick={() => {
+              localStorage.removeItem(STORAGE_KEY);
+              setShowUploadModal(true);
+            }}
+          >
+            Change CSV
+          </button>
+          {homeLocation && (
+            <button
+              onClick={flyToHomeLocation}
+              title={`Home location: ${homeLocation.location_name} (${homeLocation.checklist_count} checklists) - Your home location is calculated as the hotspot where you've submitted the most checklists`}
+            >
+              🏠 Home
+            </button>
+          )}
+          <button onClick={getCurrentLocation} title="Go to current location">
+            📍 Current Location
+          </button>
+        </div>
         <LayerToggle
           id={RootLayerIDs.HistoricalLifers}
           label="Historical lifers"
@@ -998,25 +1019,6 @@ export function BirdMap() {
             onMonthChange={setSelectedMonth}
           />
         )}
-        <button
-          onClick={() => {
-            localStorage.removeItem(STORAGE_KEY);
-            setShowUploadModal(true);
-          }}
-        >
-          Change CSV
-        </button>
-        {homeLocation && (
-          <button
-            onClick={flyToHomeLocation}
-            title={`Home location: ${homeLocation.location_name} (${homeLocation.checklist_count} checklists) - Your home location is calculated as the hotspot where you've submitted the most checklists`}
-          >
-            🏠 Home
-          </button>
-        )}
-        <button onClick={getCurrentLocation} title="Go to current location">
-          📍 Current Location
-        </button>
       </div>
       <div
         id="map-container"

--- a/src/birds-eye/BirdMap.tsx
+++ b/src/birds-eye/BirdMap.tsx
@@ -325,6 +325,7 @@ export type SpeciesFilter = 'all' | 'none' | string[];
 export function BirdMap() {
   const mapRef = useRef<Map | undefined>(undefined);
   const mapContainerRef = useRef<HTMLElement>(null);
+  const geocoderContainerRef = useRef<HTMLDivElement>(null);
 
   const [center, setCenter] = useState(INITIAL_CENTER);
   const [zoom, setZoom] = useState(INITIAL_ZOOM);
@@ -377,14 +378,17 @@ export function BirdMap() {
       zoom: INITIAL_ZOOM,
     });
 
-    // Add location search control
+    // Add location search control to custom container
     const geocoder = new MapboxGeocoder({
       accessToken: mapboxgl.accessToken,
       mapboxgl: mapboxgl,
       placeholder: 'Search for a location',
       marker: false,
     });
-    mapRef.current.addControl(geocoder, 'top-left');
+    if (geocoderContainerRef.current) {
+      geocoderContainerRef.current.innerHTML = ''; // Clear any existing content
+      geocoder.addTo(geocoderContainerRef.current);
+    }
 
     mapRef.current!.on('load', () => {
       fetchLifers(initialCenter.lat, initialCenter.lng, fileId).then((data) => {
@@ -963,6 +967,7 @@ export function BirdMap() {
         canClose={fileId !== ''}
       />
       <div className="topBar">
+        <div ref={geocoderContainerRef} className="geocoder-container" />
         <div style={{ marginBottom: '8px' }}>
           <button
             onClick={() => {


### PR DESCRIPTION
## Summary
- Move search bar from floating bottom-left to inside the topBar UI panel
- Style search bar with dark theme to match other UI elements
- Reorder topBar: buttons first, then layer radio options
- Make topBar and hotspot list full-width on mobile
- Fix search result click navigation (required manual event handling with addTo())
- Make hotspot list float over map on mobile instead of pushing map up

## Additional
- Add Git workflow guidelines to CLAUDE.md (no amend commits, no force push)

## Test plan
- [ ] Search bar appears inside the top panel
- [ ] Clicking search results navigates map to location
- [ ] Mobile: topBar is full width with consistent margins
- [ ] Mobile: hotspot list floats over map (map visible behind it)
- [ ] Search input text is white, suggestions are white
- [ ] Search box has subtle border for visibility

🤖 Generated with [Claude Code](https://claude.ai/claude-code)